### PR TITLE
Fix Gemini API Version and Request Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ npm start
 
 The server port can be changed with the `PORT` environment variable.
 Provide `OPENAI_API_KEY` to enable the AI-powered suggestion endpoint.
+
+## ShqipGPT Frontend
+
+The `shqipgpt` folder contains a small frontend chatbot.
+Set the `GEMINI_API_KEY` environment variable for the server.
+The frontend sends user prompts to `/api/ask`, which in turn calls the Gemini API
+and returns the reply.

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -32,4 +32,10 @@ describe('Poll API', () => {
     const results = await request(app).get('/poll/results');
     expect(results.body).toEqual({ A: 0, B: 0 });
   });
+
+  it('handles /api/ask', async () => {
+    const res = await request(app).post('/api/ask').send({ prompt: 'pershendetje' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('reply');
+  });
 });

--- a/api/ask.js
+++ b/api/ask.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const router = express.Router();
+
+const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';
+const apiKey = process.env.GEMINI_API_KEY;
+
+router.post('/', async (req, res) => {
+  const { prompt } = req.body;
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return res.status(400).json({ error: 'Prompt i pavlefshëm' });
+  }
+  if (!apiKey) {
+    return res.json({ reply: 'GEMINI_API_KEY mungon' });
+  }
+  try {
+    const gRes = await fetch(`${GEMINI_ENDPOINT}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+    });
+    const data = await gRes.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || 'Nuk ka përgjigje.';
+    res.json({ reply: text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Kërkesa dështoi' });
+  }
+});
+
+module.exports = router;

--- a/api/ask.ts
+++ b/api/ask.ts
@@ -1,0 +1,30 @@
+import express from 'express';
+const router = express.Router();
+
+const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';
+const apiKey = process.env.GEMINI_API_KEY;
+
+router.post('/', async (req, res) => {
+  const { prompt } = req.body as { prompt?: string };
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return res.status(400).json({ error: 'Prompt i pavlefshëm' });
+  }
+  if (!apiKey) {
+    return res.json({ reply: 'GEMINI_API_KEY mungon' });
+  }
+  try {
+    const gRes = await fetch(`${GEMINI_ENDPOINT}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+    });
+    const data = await gRes.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text || 'Nuk ka përgjigje.';
+    res.json({ reply: text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Kërkesa dështoi' });
+  }
+});
+
+export default router;

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const OpenAI = require('openai');
 const app = express();
 const openaiKey = process.env.OPENAI_API_KEY;
 const openai = openaiKey ? new OpenAI({ apiKey: openaiKey }) : null;
+const askRouter = require('./api/ask');
 app.use(cors());
 app.use(express.json());
+app.use('/api/ask', askRouter);
 
 let poll = {
   question: 'Is this poll helpful?',

--- a/shqipgpt/index.html
+++ b/shqipgpt/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="sq">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ShqipGPT – Asistenti Yt</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>ShqipGPT – Asistenti Yt</h1>
+    <textarea id="user-input" placeholder="Shkruaj pyetjen këtu..." rows="4"></textarea>
+    <button id="send-btn" onclick="handleSubmit()">Dërgo</button>
+    <div id="response"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/shqipgpt/script.js
+++ b/shqipgpt/script.js
@@ -1,0 +1,27 @@
+const responseDiv = document.getElementById('response');
+const input = document.getElementById('user-input');
+const sendBtn = document.getElementById('send-btn');
+
+async function handleSubmit() {
+  const text = input.value.trim();
+  if (!text) return;
+  sendBtn.disabled = true;
+  responseDiv.textContent = 'Duke u përgjigjur...';
+  try {
+    const res = await fetch('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: text })
+    });
+    if (!res.ok) {
+      throw new Error('Kërkesa dështoi');
+    }
+    const data = await res.json();
+    responseDiv.textContent = data.reply || 'Nuk u mor përgjigje.';
+  } catch (err) {
+    responseDiv.textContent = `Ndodhi një gabim: ${err.message}`;
+    console.error(err);
+  } finally {
+    sendBtn.disabled = false;
+  }
+}

--- a/shqipgpt/style.css
+++ b/shqipgpt/style.css
@@ -1,0 +1,55 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #e41e26; /* red */
+  color: #000; /* black text */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.container {
+  width: 90%;
+  max-width: 600px;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+h1 {
+  text-align: center;
+  color: #e41e26;
+}
+
+textarea {
+  width: 100%;
+  padding: 10px;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+}
+
+button {
+  background-color: #000;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+#response {
+  margin-top: 15px;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 15px;
+  }
+}


### PR DESCRIPTION
## Summary
- update shqipgpt frontend so button posts to `/api/ask`
- implement `/api/ask` route calling the Gemini API
- document new setup and add test for the endpoint
- disable the send button while waiting for a reply

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68607767d6dc83278a6af9f5b5d74b1a